### PR TITLE
Add scoped reservations

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -11,7 +11,7 @@ class ReservationsController < ActionController::API
       return
     end
 
-    @reservations = prep_reservation
+    @reservations = prep_reservation(Reservation.all)
     render json: @reservations, status: :ok
   end
 
@@ -100,6 +100,39 @@ class ReservationsController < ActionController::API
     render json: @my_reservations, status: :ok
   end
 
+  def today
+    unless User.admin_by_token?(request.cookies["token"])
+      render json: { error: "invalid_token" }, status: :unauthorized
+      return
+    end
+
+    @today = Reservation.today
+    @it_today = prep_reservation(@today)
+    render json: @it_today
+  end
+
+  def past
+    unless User.admin_by_token?(request.cookies["token"])
+      render json: { error: "invalid_token" }, status: :unauthorized
+      return
+    end
+
+    @past = Reservation.past
+    @it_past = prep_reservation(@past)
+    render json: @it_past
+  end
+
+  def future
+    unless User.admin_by_token?(request.cookies["token"])
+      render json: { error: "invalid_token" }, status: :unauthorized
+      return
+    end
+
+    @future = Reservation.future
+    @it_future = prep_reservation(@future)
+    render json: @it_future
+  end
+
 private
 
   # Use callbacks to share common setup or constraints between actions.
@@ -147,8 +180,8 @@ private
     (end_time - start_time) / 60
   end
 
-  def prep_reservation
-    @reservations = Reservation.all.map do |r|
+  def prep_reservation(reservations)
+    reservations.map do |r|
       {
         id: r.id,
         endTime: r.end_time,

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -4,4 +4,23 @@ class Reservation < ApplicationRecord
   default_scope { order(start_time: :desc) }
   belongs_to :user
   belongs_to :resource
+
+  def self.today
+    where(
+      "start_time <= ? AND end_time >= ?",
+      Time.now.in_time_zone("Eastern Time (US & Canada)").to_date,
+      Time.now.in_time_zone("Eastern Time (US & Canada)").to_date
+    )
+  end
+
+  def self.future
+    where("start_time > ?", Time.now.in_time_zone("Eastern Time (US & Canada)").to_date).order("start_time ASC")
+  end
+
+  def self.past
+    where(
+      "end_time <= ?",
+      Time.now.in_time_zone("Eastern Time (US & Canada)").to_date
+    ).order("start_time desc")
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
       post "create", to: "reservations#create"
       post "find_reservations", to: "reservations#find_reservations"
       delete "destroy/:id", to: "reservations#destroy"
+      get "today_reservations", to: "reservations#today"
+      get "past_reservations", to: "reservations#past"
+      get "future_reservations", to: "reservations#future"
     end
     resources :reservations
 

--- a/test/controllers/reservations_controller_test.rb
+++ b/test/controllers/reservations_controller_test.rb
@@ -112,4 +112,34 @@ class ReservationsControllerTest < ActionDispatch::IntegrationTest
       }
     assert_response :ok
   end
+
+  test "today" do
+    get today_reservations_url, headers: { "HTTP_COOKIE" => "token=" + @token + ";" }
+    assert_response :ok
+  end
+
+  test "today with no user" do
+    get today_reservations_url
+    assert_response :unauthorized
+  end
+
+  test "past" do
+    get past_reservations_url, headers: { "HTTP_COOKIE" => "token=" + @token + ";" }
+    assert_response :ok
+  end
+
+  test "past with no user" do
+    get past_reservations_url
+    assert_response :unauthorized
+  end
+
+  test "future" do
+    get future_reservations_url, headers: { "HTTP_COOKIE" => "token=" + @token + ";" }
+    assert_response :ok
+  end
+
+  test "future with no user" do
+    get future_reservations_url
+    assert_response :unauthorized
+  end
 end


### PR DESCRIPTION
We want to break out reservations into past / today / future just like parking. 

This adds API calls for that instead of having to rely on client side rendering.